### PR TITLE
Remove bouncycastle from the jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,14 @@ plugins {
 }
 
 group = "io.kubevirt"
-version = "0.0.6"
+version = "0.0.7"
 
 shadowJar {
     classifier = null
     dependencies {
         exclude(dependency {
             it.moduleGroup == 'io.sundr'
+            it.moduleGroup == 'org.bouncycastle'
         })
     }
 }


### PR DESCRIPTION
When bouncycastle is part of the jar host-deploy fails to check whether
it is possible to connect to a host.


Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>